### PR TITLE
Bugfix/issue 47/discord webhooks stopped working

### DIFF
--- a/DiscordWebook.cs
+++ b/DiscordWebook.cs
@@ -24,8 +24,8 @@ namespace ValheimServerWarden
 
         public void SendMessage(string msgSend)
         {
-            discordValues.Add("username", UserName);
-            discordValues.Add("avatar_url", ProfilePicture);
+            //discordValues.Add("username", UserName);
+            //discordValues.Add("avatar_url", ProfilePicture);
             discordValues.Remove("content");
             discordValues.Add("content", msgSend);
 

--- a/ValheimServerWarden.csproj
+++ b/ValheimServerWarden.csproj
@@ -6,14 +6,14 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>ValheimServerWarden.App</StartupObject>
-    <Version>0.4.20</Version>
-    <AssemblyVersion>0.4.20.0</AssemblyVersion>
+    <Version>0.4.21</Version>
+    <AssemblyVersion>0.4.21.0</AssemblyVersion>
     <Product>ValheimServerWarden</Product>
     <Authors>Razzmatazz</Authors>
     <ApplicationIcon>Resources\vsw2.ico</ApplicationIcon>
     <PackageId>ValheimServerWarden</PackageId>
     <AssemblyName>Valheim Server Warden</AssemblyName>
-    <FileVersion>0.4.20.0</FileVersion>
+    <FileVersion>0.4.21.0</FileVersion>
     <Company>ValheimServerWarden</Company>
   </PropertyGroup>
 


### PR DESCRIPTION
Fix: blank username and  avatar_url fields in request payload are causing 400 error. Commented out these fields which resolves the issue.